### PR TITLE
Add Apache 2.4 support on Debian Jessie

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,4 +1,8 @@
-define apache::config($ensure = 'present', $source = '', $content = '') {
+define apache::config(
+  $ensure = 'present',
+  $source = '',
+  $content = ''
+) {
  validate_string($source, $content)
   if ($ensure != 'present' and $ensure != 'absent') {
     fail("Apache::Config[$name] ensure should be one of present/absent")
@@ -11,8 +15,6 @@ define apache::config($ensure = 'present', $source = '', $content = '') {
     fail("Apache::Config[$name] cannot specify both source and content")
   }
 
-  $conf_path   = "/etc/apache2/conf.d/${name}.conf"
-
   File {
     notify  => Service['apache2'],
     ensure  => $ensure,
@@ -21,19 +23,53 @@ define apache::config($ensure = 'present', $source = '', $content = '') {
     group   => 'root',
   }
 
+  case $lsbdistcodename {
+    'jessie': { $conf_path = "/etc/apache2/conf-available/${name}.conf" }
+    default:  { $conf_path = "/etc/apache2/conf.d/${name}.conf" }
+  }
+
   if ($content) {
     file { $conf_path:
       content => $content,
     }
-  }
-  elsif ($ensure != 'absent') {
+  } elsif ($ensure != 'absent') {
     file { $conf_path:
       source => $source,
     }
-  }
-  else {
+  } else {
     file { $conf_path:
       ensure => 'absent',
+    }
+  }
+
+  case $lsbdistcodename {
+    'jessie': {
+      case $ensure {
+        'absent': {
+          $a2conf = 'a2disconf'
+          Exec["/usr/sbin/${a2conf} ${name}"] {
+            onlyif  => "/usr/bin/stat ${conf_path}",
+          }
+        }
+        default:  {
+          $a2conf = 'a2enconf'
+          Exec["/usr/sbin/${a2conf} ${name}"] {
+            creates => $conf_path
+          }
+        }
+      }
+      exec {"/usr/sbin/${a2conf} ${name}":
+        notify  => Exec['reload-apache2'],
+        require => File[$conf_path]
+      }
+      File[$conf_path] {
+        notify => Exec["/usr/sbin/${a2conf} ${name}"]
+      }
+    }
+    default: {
+      File[$conf_path] {
+        notify => Exec['reload-apache2']
+      }
     }
   }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,18 +1,18 @@
 define apache::config(
-  $ensure = 'present',
-  $source = '',
+  $ensure  = 'present',
+  $source  = '',
   $content = ''
 ) {
- validate_string($source, $content)
+  validate_string($source, $content)
   if ($ensure != 'present' and $ensure != 'absent') {
-    fail("Apache::Config[$name] ensure should be one of present/absent")
+    fail("Apache::Config[${name}] ensure should be one of present/absent")
   }
 
   if (!$content and !$source and $ensure != 'absent') {
-    fail("Apache::Config[$name] either source or content must be present")
+    fail("Apache::Config[${name}] either source or content must be present")
   }
   elsif ($content and $source) {
-    fail("Apache::Config[$name] cannot specify both source and content")
+    fail("Apache::Config[${name}] cannot specify both source and content")
   }
 
   File {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,11 +1,14 @@
-class apache($config = '', $worker = 'mpm') {
+class apache(
+  $config = '',
+  $worker = 'mpm'
+) {
   package { 'apache2':
     ensure => 'present',
   }
 
   package { 'apache2-worker':
-    name   => "apache2-mpm-worker",
     ensure => 'present',
+    name   => 'apache2-mpm-worker',
   }
 
   package { 'apache2-doc':
@@ -26,10 +29,10 @@ class apache($config = '', $worker = 'mpm') {
     require     => Package['apache2'],
   }
 
-  exec { "force-reload-apache2":
-    command     => "/etc/init.d/apache2 force-reload",
+  exec { 'force-reload-apache2':
+    command     => '/etc/init.d/apache2 force-reload',
     refreshonly => true,
-    require     => Package["apache2"],
+    require     => Package['apache2'],
   }
 
   # remove the default site

--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -1,10 +1,14 @@
-define apache::module($ensure = 'present', $config_source = '', $config_content = '') {
+define apache::module(
+  $ensure         = 'present',
+  $config_source  = '',
+  $config_content = ''
+) {
   validate_string($config_source, $config_content)
   if ($ensure != 'present' and $ensure != 'absent') {
-    fail("Apache::Module[$name] ensure must be one of present/absent")
+    fail("Apache::Module[${name}] ensure must be one of present/absent")
   }
   if ($config_content and $config_source) {
-    fail("Apache::Module[$name] cannot specify both config_source and config_content")
+    fail("Apache::Module[${name}] cannot specify both config_source and config_content")
   }
 
   $mods_enabled_path   = "/etc/apache2/mods-enabled/${name}.load"
@@ -20,8 +24,8 @@ define apache::module($ensure = 'present', $config_source = '', $config_content 
 
   if ($config_content) {
     file { $mod_config_path:
-      content => $config_content,
       ensure  => $ensure,
+      content => $config_content,
     }
   }
   elsif ($config_source) {
@@ -34,8 +38,8 @@ define apache::module($ensure = 'present', $config_source = '', $config_content 
     }
     else {
       file { $mod_config_path:
-        source => $config_source,
         ensure => $ensure,
+        source => $config_source,
       }
     }
   }

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -1,15 +1,15 @@
 define apache::site(
-  $ensure = 'present',
-  $source = '',
+  $ensure  = 'present',
+  $source  = '',
   $content = ''
 ) {
   validate_string($source, $content)
   if ($ensure != 'present' and $ensure != 'absent') {
-    fail("Apache::Site[$name] ensure should be one of present/absent")
+    fail("Apache::Site[${name}] ensure should be one of present/absent")
   }
 
   if ($content and $source) {
-    fail("Apache::Site[$name] cannot specify both source and content")
+    fail("Apache::Site[${name}] cannot specify both source and content")
   }
   case $lsbdistcodename {
     'jessie': {
@@ -30,8 +30,8 @@ define apache::site(
 
   if ($content) {
     file { $sites_available_path:
-      content => $content,
       ensure  => $ensure,
+      content => $content,
     }
   }
   elsif ($source) {
@@ -43,8 +43,8 @@ define apache::site(
       }
     } else {
       file { $sites_available_path:
-        source => $source,
         ensure => $ensure,
+        source => $source,
       }
     }
   }

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -1,4 +1,8 @@
-define apache::site($ensure = 'present', $source = '', $content = '') {
+define apache::site(
+  $ensure = 'present',
+  $source = '',
+  $content = ''
+) {
   validate_string($source, $content)
   if ($ensure != 'present' and $ensure != 'absent') {
     fail("Apache::Site[$name] ensure should be one of present/absent")
@@ -7,9 +11,16 @@ define apache::site($ensure = 'present', $source = '', $content = '') {
   if ($content and $source) {
     fail("Apache::Site[$name] cannot specify both source and content")
   }
-
-  $sites_enabled_path   = "/etc/apache2/sites-enabled/${name}"
-  $sites_available_path = "/etc/apache2/sites-available/${name}"
+  case $lsbdistcodename {
+    'jessie': {
+      $sites_enabled_path   = "/etc/apache2/sites-enabled/${name}.conf"
+      $sites_available_path = "/etc/apache2/sites-available/${name}.conf"
+    }
+    default: {
+      $sites_enabled_path   = "/etc/apache2/sites-enabled/${name}"
+      $sites_available_path = "/etc/apache2/sites-available/${name}"
+    }
+  }
 
   File {
     notify => Service['apache2'],


### PR DESCRIPTION
- Site config files now need to have the `.conf` extension
- Config files no are located in `/etc/apache2/conf-available` and are
  enabled using `a2enconf`/`a2disconf`
